### PR TITLE
Add domain models and crud utilities

### DIFF
--- a/dhi.core/domain/crud.py
+++ b/dhi.core/domain/crud.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List
+from uuid import uuid4
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from metadata.models import init_db
+from .models import Base, BankTransaction, ActionItem
+
+# Initialize database engine and session
+engine = init_db()
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+
+# Ensure tables for domain models exist
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """Yield a SQLAlchemy session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_bank_transaction(db: Session, date: date, amount: float, description: str, category: str) -> BankTransaction:
+    """Create and return a new BankTransaction."""
+    tx = BankTransaction(
+        id=str(uuid4()),
+        date=date,
+        amount=amount,
+        description=description,
+        category=category,
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return tx
+
+
+def get_bank_transactions(db: Session, skip: int = 0, limit: int = 100) -> List[BankTransaction]:
+    """List bank transactions with pagination."""
+    return db.query(BankTransaction).offset(skip).limit(limit).all()
+
+
+def create_action_item(db: Session, description: str, assigned_to: str, due_date: date, status: str, image_links: List[str], audio_links: List[str]) -> ActionItem:
+    """Create and return a new ActionItem."""
+    ai = ActionItem(
+        id=str(uuid4()),
+        description=description,
+        assigned_to=assigned_to,
+        due_date=due_date,
+        status=status,
+        image_links=image_links,
+        audio_links=audio_links,
+    )
+    db.add(ai)
+    db.commit()
+    db.refresh(ai)
+    return ai
+
+
+def get_action_items(db: Session, skip: int = 0, limit: int = 100) -> List[ActionItem]:
+    """List action items with pagination."""
+    return db.query(ActionItem).offset(skip).limit(limit).all()
+
+
+if __name__ == "__main__":
+    # Quick test of CRUD functions
+    db = next(get_db())
+    print(create_bank_transaction(db, date.today(), 12.34, "Test TX", "general"))
+    print(get_bank_transactions(db))
+    print(create_action_item(db, "Test AI", "alice", date.today(), "open", [], []))
+    print(get_action_items(db))

--- a/dhi.core/domain/models.py
+++ b/dhi.core/domain/models.py
@@ -1,0 +1,42 @@
+# Requires: pip install sqlalchemy psycopg2-binary
+
+from __future__ import annotations
+
+from sqlalchemy import Column, String, Float, Date, Text, Enum, JSON, DateTime, func
+from sqlalchemy.orm import declarative_base
+import enum
+
+Base = declarative_base()
+
+
+class BankTransaction(Base):
+    """Record of a single bank transaction."""
+
+    __tablename__ = "bank_transactions"
+
+    id = Column(String, primary_key=True)
+    date = Column(Date, nullable=False)
+    amount = Column(Float, nullable=False)
+    description = Column(String(512))
+    category = Column(String(128))
+
+
+class ActionStatus(enum.Enum):
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    CLOSED = "closed"
+
+
+class ActionItem(Base):
+    """Action item generated from a document."""
+
+    __tablename__ = "action_items"
+
+    id = Column(String, primary_key=True)
+    description = Column(Text, nullable=False)
+    assigned_to = Column(String(128))
+    due_date = Column(Date)
+    status = Column(Enum(ActionStatus), default=ActionStatus.OPEN)
+    image_links = Column(JSON, default=list)
+    audio_links = Column(JSON, default=list)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
## Summary
- add new `dhi.core/domain` package
- define SQLAlchemy models `BankTransaction` and `ActionItem`
- implement CRUD helpers using SQLAlchemy sessions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852673967988323952a2e1d2c2717af